### PR TITLE
fix: add socketTimeout and limit fetched messages to prevent IMAP hangs

### DIFF
--- a/src/imap-client.ts
+++ b/src/imap-client.ts
@@ -10,6 +10,7 @@ export interface IMAPConfig {
   tls?: boolean;
   connTimeout?: number;
   authTimeout?: number;
+  socketTimeout?: number;
   keepalive?: boolean;
 }
 
@@ -71,7 +72,7 @@ export class IMAPClient extends EventEmitter {
     return new Promise((resolve, reject) => {
       console.error(`[IMAP] Connecting to ${this.config.host}:${this.config.port} (TLS: ${this.config.tls})`);
       
-      const imapConfig: Imap.Config = {
+      const imapConfig: Imap.Config & { socketTimeout?: number } = {
         user: this.config.username,
         password: this.config.password,
         host: this.config.host,
@@ -83,6 +84,7 @@ export class IMAPClient extends EventEmitter {
         },
         connTimeout: this.config.connTimeout || 60000,
         authTimeout: this.config.authTimeout || 30000,
+        socketTimeout: this.config.socketTimeout || 60000,
         keepalive: this.config.keepalive !== false
       };
 
@@ -481,22 +483,24 @@ export class IMAPClient extends EventEmitter {
   }
 
   async getMessageCount(): Promise<number> {
-    if (!this.currentBox) {
-      await this.openBox('INBOX', true);
-    }
-    
-    const uids = await this.search(['ALL']);
-    return uids.length;
+    // Use openBox to get message count directly from server STATUS,
+    // instead of SEARCH ALL which can be extremely slow on large mailboxes
+    const boxInfo = await this.openBox(this.currentBox || 'INBOX', true);
+    return boxInfo.messages.total;
   }
 
-  async getUnseenMessages(): Promise<EmailMessage[]> {
+  async getUnseenMessages(limit: number = 50): Promise<EmailMessage[]> {
     const unseenUids = await this.search(['UNSEEN']);
-    return this.fetchMessages(unseenUids);
+    // Only fetch the most recent N messages to avoid timeout on large mailboxes
+    const limitedUids = unseenUids.slice(-limit);
+    return this.fetchMessages(limitedUids);
   }
 
-  async getRecentMessages(): Promise<EmailMessage[]> {
+  async getRecentMessages(limit: number = 50): Promise<EmailMessage[]> {
     const recentUids = await this.search(['RECENT']);
-    return this.fetchMessages(recentUids);
+    // Only fetch the most recent N messages to avoid timeout on large mailboxes
+    const limitedUids = recentUids.slice(-limit);
+    return this.fetchMessages(limitedUids);
   }
 
   private parseHeaders(headerText: string): Record<string, string> {

--- a/src/imap-client.ts
+++ b/src/imap-client.ts
@@ -82,9 +82,9 @@ export class IMAPClient extends EventEmitter {
           rejectUnauthorized: false,
           servername: this.config.host
         },
-        connTimeout: this.config.connTimeout || 60000,
-        authTimeout: this.config.authTimeout || 30000,
-        socketTimeout: this.config.socketTimeout || 60000,
+        connTimeout: this.config.connTimeout ?? 60000,
+        authTimeout: this.config.authTimeout ?? 30000,
+        socketTimeout: this.config.socketTimeout ?? 60000,
         keepalive: this.config.keepalive !== false
       };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -382,18 +382,28 @@ class MailMCPServer {
           },
           {
             name: 'get_unseen_messages',
-            description: 'Get all unseen (unread) messages. Auto-connects if not already connected.',
+            description: 'Get unseen (unread) messages. Returns the most recent unseen messages up to the specified limit. Auto-connects if not already connected.',
             inputSchema: {
               type: 'object',
-              properties: {},
+              properties: {
+                limit: {
+                  type: 'number',
+                  description: 'Maximum number of messages to fetch (default: 50)',
+                },
+              },
             },
           },
           {
             name: 'get_recent_messages',
-            description: 'Get all recent messages. Auto-connects if not already connected.',
+            description: 'Get recent messages. Returns the most recent messages up to the specified limit. Auto-connects if not already connected.',
             inputSchema: {
               type: 'object',
-              properties: {},
+              properties: {
+                limit: {
+                  type: 'number',
+                  description: 'Maximum number of messages to fetch (default: 50)',
+                },
+              },
             },
           },
           {
@@ -826,9 +836,9 @@ class MailMCPServer {
           case 'get_message_count':
             return await this.handleGetMessageCount();
           case 'get_unseen_messages':
-            return await this.handleGetUnseenMessages();
+            return await this.handleGetUnseenMessages(args?.limit as number | undefined);
           case 'get_recent_messages':
-            return await this.handleGetRecentMessages();
+            return await this.handleGetRecentMessages(args?.limit as number | undefined);
           case 'get_connection_status':
             return await this.handleGetConnectionStatus();
           case 'send_email':
@@ -1717,12 +1727,13 @@ class MailMCPServer {
     }
   }
 
-  private async handleGetUnseenMessages() {
+  private async handleGetUnseenMessages(limit?: number) {
     await this.ensureRequiredConnections(true, false);
 
     try {
-      const messages = await this.imapClient!.getUnseenMessages();
-      
+      const fetchLimit = limit && limit > 0 ? limit : 50;
+      const messages = await this.imapClient!.getUnseenMessages(fetchLimit);
+
       return {
         content: [
           {
@@ -1736,12 +1747,13 @@ class MailMCPServer {
     }
   }
 
-  private async handleGetRecentMessages() {
+  private async handleGetRecentMessages(limit?: number) {
     await this.ensureRequiredConnections(true, false);
 
     try {
-      const messages = await this.imapClient!.getRecentMessages();
-      
+      const fetchLimit = limit && limit > 0 ? limit : 50;
+      const messages = await this.imapClient!.getRecentMessages(fetchLimit);
+
       return {
         content: [
           {


### PR DESCRIPTION
## Summary

- **Add `socketTimeout` (default 60s)** to IMAP connection config. Previously only `connTimeout` and `authTimeout` were set, while `socketTimeout` defaulted to `0` (no timeout). This caused IMAP operations (SEARCH, FETCH) to hang indefinitely when the server stopped responding after connection was established.
- **Fix `getMessageCount()`** to use mailbox STATUS info from `openBox()` instead of `SEARCH ALL`. The previous implementation searched all messages and counted the results, which is extremely slow on large mailboxes.
- **Add `limit` parameter** to `getUnseenMessages()` and `getRecentMessages()` (default: 50). Previously these methods fetched ALL matching messages with full HEADER+TEXT+envelope, which could take hours on mailboxes with many unread messages. Now only the most recent N messages are fetched.
- **Expose `limit` parameter** in MCP tool definitions for `get_unseen_messages` and `get_recent_messages`.

## Problem

When using `get_unseen_messages` or `get_message_count` on a mailbox with many messages (e.g., 163 enterprise mail), the IMAP operations would hang for hours (observed 9+ hours) because:
1. No `socketTimeout` was configured, so stalled connections never timed out
2. `getMessageCount()` used `SEARCH ALL` instead of mailbox STATUS
3. `getUnseenMessages()` fetched ALL unread messages without any limit

## Test plan

- [x] Project builds cleanly with `npm run build` (no errors or warnings)
- [ ] Verify `get_message_count` returns correct count without delay
- [ ] Verify `get_unseen_messages` with default limit returns quickly
- [ ] Verify `get_unseen_messages` with custom `limit` parameter works
- [ ] Verify connection properly times out after 60s of socket inactivity

🤖 Generated with [Claude Code](https://claude.com/claude-code)